### PR TITLE
Redirects

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -9,13 +9,14 @@ import cidrLogo from "../assets/cidr.trsp.no-text.280x140.png";
 const commit = execSync("git rev-parse --short HEAD").toString().trim();
 const datetime = new Date().toISOString();
 
-let { title, description = siteConfig.defaultDescription } = Astro.props;
+let { title, description = siteConfig.defaultDescription, redirect } = Astro.props;
 
 title = title ? `${title} :: ${siteConfig.baseTitle}` : siteConfig.baseTitle;
 ---
 
 <head prefix="dcterms: http://purl.org/dc/terms/#">
   <meta charset="UTF-8" />
+  { redirect && <meta http-equiv="refresh" content=`0; URL=${redirect}` />}
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <meta name="description" property="og:description" content={description} />

--- a/src/layouts/redirect.astro
+++ b/src/layouts/redirect.astro
@@ -1,0 +1,32 @@
+---
+import "@fontsource/source-sans-pro/300.css";
+import "@fontsource/source-sans-pro/400.css";
+import "@fontsource/source-sans-pro/600.css";
+
+import Head from "../components/Head.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+
+let { title, redirect } = Astro.props.content || Astro.props;
+
+const content = await Astro.slots.render("default");
+---
+
+<html lang="en">
+  <Head {title} {redirect} />
+  <body>
+    <Header />
+    <main>
+      {
+        content ? (
+          <div set:html={content} />
+        ) : (
+          <div>
+            Please wait while you are redirected, or click <a href={redirect}>here</a>.
+          </div>
+        )
+      }
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/layouts/workshop-landing-page.astro
+++ b/src/layouts/workshop-landing-page.astro
@@ -1,0 +1,71 @@
+---
+import RedirectLayout from "./redirect.astro";
+
+let { title, when, redirect } = Astro.props.content || Astro.props;
+
+const content = await Astro.slots.render("default");
+---
+
+<RedirectLayout {title} {redirect}>
+  {
+    content ? (
+      <article set:html={content} />
+    ) : (
+      <article>
+        <header>
+          <h1 set:text={title} />
+          <h3 set:text={when}>
+        </header>
+        <div>
+          <p>
+            Please visit:
+            <br />
+            <a href={redirect} set:text={Astro.url} />
+          </p>
+        </div>
+      </article>
+    )
+  }
+</RedirectLayout>
+<style>
+  article {
+    background: var(--fog-light);
+    border-radius: 0.25em;
+    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175);
+    display: grid;
+    flex-grow: 1;
+    margin: 0 auto;
+    max-width: 755px;
+    min-width: 94vw;
+    padding: 20px;
+    place-content: center;
+    text-align: center;
+  }
+
+  h1 {
+    color: var(--primary);
+    font-size: 40px;
+    font-weight: 500;
+    margin-bottom: 0;
+    text-decoration-color: rgba(38, 50, 56, 0.2);
+    text-decoration: underline;
+    width: 100%;
+  }
+
+  p {
+    margin-top: 4rem;
+  }
+
+  a {
+    color: var(--cardinal);
+    font-size: min(72px, 5vw);
+    font-weight: bold;
+  }
+
+  :global(body main) {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    width: 100%;
+  }
+</style>

--- a/src/pages/intro-to-python.md
+++ b/src/pages/intro-to-python.md
@@ -1,0 +1,6 @@
+---
+layout: ../layouts/workshop-landing-page.astro
+title: Introduction to Python
+when: Thursday, October 12th, 1-3pm
+redirect: https://colab.research.google.com/github/sul-cidr/Workshops/blob/master/Introduction_to_Python/Introduction%20to%20Python.ipynb
+---


### PR DESCRIPTION
This PR adds HTML meta refresh-based redirects to the CIDR site, including a special-case for workshop landing pages (we can't use server-level redirects on GitHub Pages, sadly).  It's still a bit experimental, but I'll be using it this afternoon, so it's going in now.  Once it's stable and polished I'll write up instructions for folks to add their own _ad libitum_.